### PR TITLE
Fix home template fade button on device

### DIFF
--- a/example_django/templates/home.html
+++ b/example_django/templates/home.html
@@ -63,7 +63,7 @@
                         class="bg-purple-500 hover:bg-purple-600 text-white font-bold py-2 px-4 rounded transition duration-200"
                         hx-get="/time/"
                         hx-target="#counter-result"
-                        hx-swap="innerHTML swap:1s">
+                        hx-swap="innerHTML transition:true">
                         Fade Swap
                     </button>
                     <button 
@@ -74,7 +74,7 @@
                         Outer Swap
                     </button>
                 </div>
-                <div id="counter-result" class="mt-4 p-4 bg-gray-100 rounded-lg">
+                <div id="counter-result" class="mt-4 p-4 bg-gray-100 rounded-lg transition-opacity duration-500">
                     <p class="text-gray-700">Click a button to see different swap effects!</p>
                 </div>
             </div>


### PR DESCRIPTION
Fix 'Fade Swap' button to correctly animate fading by updating HTMX swap and adding CSS transitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-301c0ab9-4dd6-45a5-8b9d-31ebc98b96eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-301c0ab9-4dd6-45a5-8b9d-31ebc98b96eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

