### PR TITLE
Demonstrate sse with htmx and django

### DIFF
--- a/example_django/templates/home.html
+++ b/example_django/templates/home.html
@@ -6,6 +6,7 @@
     <title>HTMX Demo - Home</title>
     <!-- HTMX -->
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/sse.js"></script>
     <!-- Tailwind CSS + DaisyUI -->
     <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
@@ -106,7 +107,34 @@
                 </div>
             </div>
 
-            <!-- Card 4: Information -->
+            <!-- Card 4: Server-Sent Events (SSE) Demo -->
+            <div class="card card-border bg-base-100 shadow-xl">
+                <div class="card-body">
+                    <h2 class="card-title">Server-Sent Events (SSE)</h2>
+                    <p>Watch real-time updates streamed from the server using SSE and htmx.</p>
+                    <div class="card-actions">
+                        <button 
+                            class="btn btn-primary"
+                            hx-ext="sse"
+                            sse-connect="/sse/"
+                            sse-swap="message"
+                            hx-target="#sse-result"
+                            hx-swap="beforeend">
+                            Start SSE Stream
+                        </button>
+                        <button 
+                            class="btn btn-secondary"
+                            onclick="document.getElementById('sse-result').innerHTML = ''">
+                            Clear
+                        </button>
+                    </div>
+                    <div id="sse-result" class="mt-4 max-h-64 overflow-y-auto">
+                        <!-- SSE updates will be displayed here -->
+                    </div>
+                </div>
+            </div>
+
+            <!-- Card 5: Information -->
             <div class="card card-border bg-base-100 shadow-xl">
                 <div class="card-body">
                     <h2 class="card-title">About HTMX</h2>

--- a/example_django/urls.py
+++ b/example_django/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('time/', views.get_current_time, name='get_time'),
     path('greet/', views.greet, name='greet'),
+    path('sse/', views.sse_stream, name='sse_stream'),
     path('admin/', admin.site.urls),
     path('accounts/', include("django.contrib.auth.urls")),
 ]

--- a/example_django/views.py
+++ b/example_django/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 import datetime
+import time
+import json
 
 
 def home(request):
@@ -18,3 +20,32 @@ def greet(request):
     """HTMX endpoint that returns a greeting."""
     name = request.GET.get('name', 'Guest')
     return HttpResponse(f"<div class='p-4 bg-green-100 rounded-lg'><p class='text-green-800'>Hello, {name}! Welcome to the HTMX demo.</p></div>")
+
+
+def sse_stream(request):
+    """Server-Sent Events endpoint that streams updates."""
+    def event_stream():
+        """Generator function that yields SSE formatted data."""
+        for i in range(10):  # Send 10 updates
+            # Get current timestamp
+            current_time = datetime.datetime.now().strftime("%H:%M:%S")
+            
+            # Create the HTML content to send
+            html_content = f'<div class="alert alert-info mb-2">Update #{i + 1} at {current_time}</div>'
+            
+            # Format as SSE
+            # SSE format: "data: <content>\n\n"
+            yield f"data: {html_content}\n\n"
+            
+            # Wait 1 second before sending next update
+            time.sleep(1)
+        
+        # Send a final message
+        final_html = '<div class="alert alert-success">Stream completed!</div>'
+        yield f"data: {final_html}\n\n"
+    
+    # Return StreamingHttpResponse with SSE content type
+    response = StreamingHttpResponse(event_stream(), content_type='text/event-stream')
+    response['Cache-Control'] = 'no-cache'
+    response['X-Accel-Buffering'] = 'no'  # Disable buffering in nginx
+    return response


### PR DESCRIPTION
Add a simple demonstration of Server-Sent Events (SSE) using htmx and Django's StreamingHttpResponse.

---
<a href="https://cursor.com/background-agent?bcId=bc-984cb820-a94a-4709-8ec2-18e4ecad9abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-984cb820-a94a-4709-8ec2-18e4ecad9abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

