### PR TITLE
Check static file configuration

### DIFF
--- a/example_django/settings.py
+++ b/example_django/settings.py
@@ -153,7 +153,6 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 STATICFILES_DIRS = [
     BASE_DIR / 'static',
 ]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Django Compressor settings for Flowbite
 COMPRESS_ROOT = BASE_DIR / 'static'

--- a/example_django/urls.py
+++ b/example_django/urls.py
@@ -14,6 +14,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
 from . import views
@@ -26,3 +28,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('accounts/', include("django.contrib.auth.urls")),
 ]
+
+# Serve static files in development
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Remove deprecated `STATICFILES_STORAGE` setting and add development static file serving.

The `STATICFILES_STORAGE` setting is deprecated in Django 4.2+ and was conflicting with the modern `STORAGES` configuration. Adding static file serving to `urls.py` ensures static files are correctly served during development (`DEBUG=True`).

---
<a href="https://cursor.com/background-agent?bcId=bc-16553f49-fed7-4611-8f07-134cf213b313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16553f49-fed7-4611-8f07-134cf213b313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

