### PR TITLE
Remove whitenoise in favor of compressor

### DIFF
--- a/example_django/settings.py
+++ b/example_django/settings.py
@@ -43,7 +43,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -180,7 +179,7 @@ STORAGES = {
         },
     },
     "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
     },
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ asgiref
 Django==5.2
 uvicorn[standard]
 sqlparse
-whitenoise
 django-storages[s3]
 psycopg2-binary
 django-compressor


### PR DESCRIPTION
Remove Whitenoise since django-compressor is now used for static file handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-4857303b-a8d7-480e-bbc7-9a7c70d94120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4857303b-a8d7-480e-bbc7-9a7c70d94120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

